### PR TITLE
fix(bento): allow item lists smaller than k

### DIFF
--- a/bento2seldon4recsys/bento.py
+++ b/bento2seldon4recsys/bento.py
@@ -135,7 +135,9 @@ class _FeedbackMixin(Generic[RT, RE]):
                 ]
                 logger.debug("relevance_scores: %s", relevance_scores)
 
-                ks = [min(len(relevance_scores), request.jsonData.top_k)]
+                ks = []
+                if request.jsonData.top_k <= len(relevance_scores):
+                    ks.append(request.jsonData.top_k)
                 if 10 < request.jsonData.top_k and 10 <= len(relevance_scores):
                     ks.append(10)
                 if 50 < request.jsonData.top_k and 50 <= len(relevance_scores):

--- a/bento2seldon4recsys/bento.py
+++ b/bento2seldon4recsys/bento.py
@@ -135,10 +135,10 @@ class _FeedbackMixin(Generic[RT, RE]):
                 ]
                 logger.debug("relevance_scores: %s", relevance_scores)
 
-                ks = [request.jsonData.top_k]
-                if 10 < request.jsonData.top_k:
+                ks = [min(len(relevance_scores), request.jsonData.top_k)]
+                if 10 < request.jsonData.top_k and 10 <= len(relevance_scores):
                     ks.append(10)
-                if 50 < request.jsonData.top_k:
+                if 50 < request.jsonData.top_k and 50 <= len(relevance_scores):
                     ks.append(50)
 
                 for k in set(ks):


### PR DESCRIPTION
## Description

Currently the library only accepts feedback for recommended `item_ids` with length of at least `k`. This Pull Request makes `_FeedbackMixin` accept feedback for recommendations where `item_ids` are smaller than `k`.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [X] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/deeplearningbrasil/bento2seldon4recsys/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I've read the [`CONTRIBUTING.md`](https://github.com/deeplearningbrasil/bento2seldon4recsys/blob/master/CONTRIBUTING.md) guide.
- [X] I've updated the code style using `make codestyle`.
- [X] I've written tests for all new methods and classes that I created.
- [X] I've written the docstring in Google format for all the methods and classes that I used.
