### PR TITLE
Support for extra Prometheus labels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.7
+  python: python3.8
 
 default_stages: [commit, push]
 
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: pyupgrade
         name: pyupgrade
-        entry: poetry run pyupgrade --py37-plus
+        entry: poetry run pyupgrade --py38-plus
         types: [python]
         language: system
 

--- a/bento2seldon4recsys/bento.py
+++ b/bento2seldon4recsys/bento.py
@@ -144,10 +144,10 @@ class _FeedbackMixin(Generic[RT, RE]):
                     ks.append(50)
 
                 extra = {}
-                if hasattr(self, "_extra_monitor_request_info"):
+                if hasattr(self, "extra_monitor_request_info"):
                     extra = {
                         label: getattr(request.jsonData, label)
-                        for label in self._extra_monitor_request_info
+                        for label in self.extra_monitor_request_info
                     }
 
                 for k in set(ks):

--- a/bento2seldon4recsys/bento.py
+++ b/bento2seldon4recsys/bento.py
@@ -99,6 +99,10 @@ class _FeedbackMixin(Generic[RT, RE]):
             self._monitor = RecommenderMonitor(self)
         return self._monitor
 
+    @property
+    def extra_monitoring_request_fields(self) -> List[str]:
+        return []
+
     def _should_threat_feedback(self, response: SeldonMessage[RE]) -> bool:
         return (
             response.meta.tags.get(PRED_UNIT_KEY) == PRED_UNIT_ID
@@ -143,12 +147,10 @@ class _FeedbackMixin(Generic[RT, RE]):
                 if 50 < request.jsonData.top_k and 50 <= len(relevance_scores):
                     ks.append(50)
 
-                extra = {}
-                if hasattr(self, "extra_monitor_request_info"):
-                    extra = {
-                        label: getattr(request.jsonData, label)
-                        for label in self.extra_monitor_request_info
-                    }
+                extra = {
+                    label: getattr(request.jsonData, label)
+                    for label in self.extra_monitoring_request_fields
+                }
 
                 for k in set(ks):
                     logger.debug("Calculating metrics for k=%d", k)

--- a/bento2seldon4recsys/bento.py
+++ b/bento2seldon4recsys/bento.py
@@ -143,14 +143,23 @@ class _FeedbackMixin(Generic[RT, RE]):
                 if 50 < request.jsonData.top_k and 50 <= len(relevance_scores):
                     ks.append(50)
 
+                extra = {}
+                if hasattr(self, "_extra_monitor_request_info"):
+                    extra = {
+                        label: getattr(request.jsonData, label)
+                        for label in self._extra_monitor_request_info
+                    }
+
                 for k in set(ks):
                     logger.debug("Calculating metrics for k=%d", k)
-                    self.monitor.observe_ndcg(ndcg_at_k(relevance_scores, k), k)
+                    self.monitor.observe_ndcg(
+                        ndcg_at_k(relevance_scores, k), k, extra=extra
+                    )
                     self.monitor.observe_precision(
-                        precision_at_k(relevance_scores, k), k
+                        precision_at_k(relevance_scores, k), k, extra=extra
                     )
                 self.monitor.observe_average_precision(
-                    average_precision(relevance_scores)
+                    average_precision(relevance_scores), extra=extra
                 )
 
 

--- a/bento2seldon4recsys/monitoring.py
+++ b/bento2seldon4recsys/monitoring.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional
+from typing import Any, Dict
 
 from bento2seldon.monitoring import FEEDBACK_ENDPOINT, Monitor
 from bento2seldon.seldon import DEPLOYMENT_ID
@@ -7,42 +7,23 @@ from prometheus_client.metrics import Histogram
 
 
 class RecommenderMonitor(Monitor):
-    def __init__(
-        self,
-        bento_service: BentoService,
-        extra_labels_per_metric: Optional[Dict[str, List[str]]] = {},
-    ) -> None:
-        super().__init__(bento_service, extra_labels_per_metric)
-
-        self._ndcg = self._create_metric(
-            Histogram,
-            "ndcg",
-            "nDCG@k",
-            ["k"],
-        )
-
-        self._precision = self._create_metric(
-            Histogram,
-            "precision",
-            "precision@k",
-            ["k"],
-        )
-
-        self._average_precision = self._create_metric(
-            Histogram,
-            "average_precision",
-            "_average_precision",
-        )
+    def __init__(self, bento_service: BentoService) -> None:
+        super().__init__(bento_service)
 
     def observe_ndcg(
         self,
         value: float,
         k: int,
         endpoint: str = FEEDBACK_ENDPOINT,
-        extra_labels_values: list = [],
+        extra: Dict[str, Any] = {},
     ) -> None:
+        if not hasattr(self, "_ndcg"):
+            self._ndcg = self._create_metric(
+                Histogram, "ndcg", "nDCG@k", ["k", *extra.keys()],
+            )
+
         self._ndcg.labels(
-            DEPLOYMENT_ID, self.version, endpoint, *extra_labels_values, k
+            DEPLOYMENT_ID, self.version, endpoint, k, *extra.values()
         ).observe(value)
 
     def observe_precision(
@@ -50,18 +31,28 @@ class RecommenderMonitor(Monitor):
         value: float,
         k: int,
         endpoint: str = FEEDBACK_ENDPOINT,
-        extra_labels_values: list = [],
+        extra: Dict[str, Any] = {},
     ) -> None:
+        if not hasattr(self, "_precision"):
+            self._precision = self._create_metric(
+                Histogram, "precision", "precision@k", ["k", *extra.keys()]
+            )
+
         self._precision.labels(
-            DEPLOYMENT_ID, self.version, endpoint, *extra_labels_values, k
+            DEPLOYMENT_ID, self.version, endpoint, k, *extra.values()
         ).observe(value)
 
     def observe_average_precision(
         self,
         value: float,
         endpoint: str = FEEDBACK_ENDPOINT,
-        extra_labels_values: list = [],
+        extra: Dict[str, Any] = {},
     ) -> None:
+        if not hasattr(self, "_average_precision"):
+            self._average_precision = self._create_metric(
+                Histogram, "average_precision", "_average_precision", extra.keys()
+            )
+
         self._average_precision.labels(
-            DEPLOYMENT_ID, self.version, endpoint, *extra_labels_values
+            DEPLOYMENT_ID, self.version, endpoint, *extra.values()
         ).observe(value)

--- a/bento2seldon4recsys/monitoring.py
+++ b/bento2seldon4recsys/monitoring.py
@@ -1,3 +1,5 @@
+from typing import Dict, List, Optional
+
 from bento2seldon.monitoring import FEEDBACK_ENDPOINT, Monitor
 from bento2seldon.seldon import DEPLOYMENT_ID
 from bentoml import BentoService
@@ -5,8 +7,12 @@ from prometheus_client.metrics import Histogram
 
 
 class RecommenderMonitor(Monitor):
-    def __init__(self, bento_service: BentoService) -> None:
-        super().__init__(bento_service)
+    def __init__(
+        self,
+        bento_service: BentoService,
+        extra_labels_per_metric: Optional[Dict[str, List[str]]] = {},
+    ) -> None:
+        super().__init__(bento_service, extra_labels_per_metric)
 
         self._ndcg = self._create_metric(
             Histogram,
@@ -29,18 +35,33 @@ class RecommenderMonitor(Monitor):
         )
 
     def observe_ndcg(
-        self, value: float, k: int, endpoint: str = FEEDBACK_ENDPOINT
+        self,
+        value: float,
+        k: int,
+        endpoint: str = FEEDBACK_ENDPOINT,
+        extra_labels_values: list = [],
     ) -> None:
-        self._ndcg.labels(DEPLOYMENT_ID, self.version, endpoint, k).observe(value)
+        self._ndcg.labels(
+            DEPLOYMENT_ID, self.version, endpoint, *extra_labels_values, k
+        ).observe(value)
 
     def observe_precision(
-        self, value: float, k: int, endpoint: str = FEEDBACK_ENDPOINT
+        self,
+        value: float,
+        k: int,
+        endpoint: str = FEEDBACK_ENDPOINT,
+        extra_labels_values: list = [],
     ) -> None:
-        self._precision.labels(DEPLOYMENT_ID, self.version, endpoint, k).observe(value)
+        self._precision.labels(
+            DEPLOYMENT_ID, self.version, endpoint, *extra_labels_values, k
+        ).observe(value)
 
     def observe_average_precision(
-        self, value: float, endpoint: str = FEEDBACK_ENDPOINT
+        self,
+        value: float,
+        endpoint: str = FEEDBACK_ENDPOINT,
+        extra_labels_values: list = [],
     ) -> None:
-        self._average_precision.labels(DEPLOYMENT_ID, self.version, endpoint).observe(
-            value
-        )
+        self._average_precision.labels(
+            DEPLOYMENT_ID, self.version, endpoint, *extra_labels_values
+        ).observe(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 importlib_metadata = {version = "^4.5.0", python = "<3.8"}
-bento2seldon = ">=0.3.4"
+bento2seldon = ">=0.4.0"
 pandas = ">=0.23"
 scikit-learn = ">=0.18"
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "bento2seldon4recsys"
-version = "0.1.2"
+version = "0.1.3"
 description = "Extension of bento2seldon for RecSys."
 readme = "README.md"
 authors = ["fernandocamargoai <fernando.camargo.ai@gmail.com>"]
@@ -34,7 +34,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 importlib_metadata = {version = "^4.5.0", python = "<3.8"}
-bento2seldon = ">=0.3"
+bento2seldon = ">=0.3.4"
 pandas = ">=0.23"
 scikit-learn = ">=0.18"
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
## Description

This pull request adds support for extra labels on Prometheus monitoring. This is and will be used for time-series segregation on different contexts (seller_ids on marketplaces, for example).

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [X] 🥂 Improvement (non-breaking change which improves an existing feature)
- [X] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [X] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/fernandocamargoai/bento2seldon/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I've read the [`CONTRIBUTING.md`](https://github.com/fernandocamargoai/bento2seldon/blob/master/CONTRIBUTING.md) guide.
- [X] I've updated the code style using `make codestyle`.
- [X] I've written tests for all new methods and classes that I created.
- [X] I've written the docstring in Google format for all the methods and classes that I used.